### PR TITLE
Added message_definition field to connection header

### DIFF
--- a/src/record_types/connection.rs
+++ b/src/record_types/connection.rs
@@ -24,6 +24,8 @@ pub struct Connection<'a> {
     pub tp: &'a str,
     /// MD5 hash sum of the message type
     pub md5sum: [u8; 16],
+    /// Full text of the message definition
+    pub message_definition: &'a str,
     /// Name of node sending data (can be empty)
     pub caller_id: &'a str,
     /// Is publisher in the latching mode? (i.e. sends the last value published
@@ -49,6 +51,7 @@ impl<'a> RecordGen<'a> for Connection<'a> {
         let mut topic = None;
         let mut tp = None;
         let mut md5sum = None;
+        let mut message_definition = None;
         let mut caller_id = None;
         let mut latching = false;
 
@@ -65,6 +68,7 @@ impl<'a> RecordGen<'a> for Connection<'a> {
                     base16ct::lower::decode(val, &mut res).map_err(|_| Error::InvalidRecord)?;
                     md5sum = Some(res);
                 }
+                "message_definition" => set_field_str(&mut message_definition, val)?,
                 "callerid" => set_field_str(&mut caller_id, val)?,
                 "latching" => {
                     latching = match val {
@@ -80,6 +84,7 @@ impl<'a> RecordGen<'a> for Connection<'a> {
         let topic = topic.ok_or(Error::InvalidHeader)?;
         let tp = tp.ok_or(Error::InvalidHeader)?;
         let md5sum = md5sum.ok_or(Error::InvalidHeader)?;
+        let message_definition = message_definition.ok_or(Error::InvalidHeader)?;
         let caller_id = caller_id.unwrap_or("");
         Ok(Self {
             id,
@@ -87,6 +92,7 @@ impl<'a> RecordGen<'a> for Connection<'a> {
             topic,
             tp,
             md5sum,
+            message_definition,
             caller_id,
             latching,
         })


### PR DESCRIPTION
This fix adds the `message_definition` field to the connection header, which is a mandatory field according to the [bag file specification](https://wiki.ros.org/Bags/Format/2.0#Connection). It also gets rid of the `warn!` log message triggered by this field.